### PR TITLE
Include buffer/cache memory as free memory on linux

### DIFF
--- a/memory_linux.go
+++ b/memory_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package memory
@@ -25,5 +26,9 @@ func sysFreeMemory() uint64 {
 	// If this is a 32-bit system, then these fields are
 	// uint32 instead of uint64.
 	// So we always convert to uint64 to match signature.
-	return uint64(in.Freeram) * uint64(in.Unit)
+	// Buffer/cache ram is included on linux since the kernel
+	// will free this memory for applications if needed, and tends
+	// to use almost all free memory for itself when it can.
+	// https://pkg.go.dev/syscall#Sysinfo_t
+	return (uint64(in.Freeram) + uint64(in.Bufferram)) * uint64(in.Unit)
 }


### PR DESCRIPTION
The Linux kernel will typically use almost all free memory for buffering/cache purposes such as the page cache, freeing immediately as needed for applications. This buffer should be considered free memory.