### PR TITLE
Include available memory

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -22,3 +22,13 @@ func TotalMemory() uint64 {
 func FreeMemory() uint64 {
 	return sysFreeMemory()
 }
+
+// AvailableMemory returns the total free+freeable system memory in bytes.
+//
+// The total available memory is the free memory + freeable memory
+// such as buffer and cache.
+//
+// If available memory size could not be determined, then 0 is returned.
+func AvailableMemory() uint64 {
+	return sysAvailableMemory()
+}

--- a/memory_bsd.go
+++ b/memory_bsd.go
@@ -1,3 +1,4 @@
+//go:build freebsd || openbsd || dragonfly || netbsd
 // +build freebsd openbsd dragonfly netbsd
 
 package memory
@@ -16,4 +17,8 @@ func sysFreeMemory() uint64 {
 		return 0
 	}
 	return s
+}
+
+func sysAvailableMemory() uint64 {
+	return sysFreeMemory()
 }

--- a/memory_darwin.go
+++ b/memory_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package memory
@@ -46,4 +47,8 @@ func sysFreeMemory() uint64 {
 		}
 	}
 	return freePages * pageSize
+}
+
+func sysAvailableMemory() uint64 {
+	return sysFreeMemory()
 }

--- a/memory_linux.go
+++ b/memory_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package memory
@@ -26,4 +27,19 @@ func sysFreeMemory() uint64 {
 	// uint32 instead of uint64.
 	// So we always convert to uint64 to match signature.
 	return uint64(in.Freeram) * uint64(in.Unit)
+}
+
+func sysAvailableMemory() uint64 {
+	in := &syscall.Sysinfo_t{}
+	err := syscall.Sysinfo(in)
+	if err != nil {
+		return 0
+	}
+	// If this is a 32-bit system, then these fields are
+	// uint32 instead of uint64.
+	// So we always convert to uint64 to match signature.
+	// Buffer/cache ram is included on linux since the kernel
+	// will free this memory for applications if needed, and tends
+	// to use almost all free memory for itself when it can.
+	return (uint64(in.Freeram) + uint64(in.Bufferram)) * uint64(in.Unit)
 }

--- a/memory_windows.go
+++ b/memory_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package memory
@@ -57,4 +58,8 @@ func sysFreeMemory() uint64 {
 		return 0
 	}
 	return msx.ullAvailPhys
+}
+
+func sysAvailableMemory() uint64 {
+	return sysFreeMemory()
 }


### PR DESCRIPTION
From the discussion in #9, this is the AvailableMemory() function addition.

It intends to return free+freeable memory.

I think Windows is ready to go as-is, and this adds the change for Linux. Darwin and BSDs remain and I could use some help there.

- [x] Linux
- [x] Windows - _I think it's using available memory already_
- [ ] Darwin
- [ ] BSD